### PR TITLE
Add detection of arrays with duplicating key values

### DIFF
--- a/src/PleskX/Api/Client.php
+++ b/src/PleskX/Api/Client.php
@@ -345,13 +345,26 @@ class Client
     {
         foreach ($array as $key => $value) {
             if (is_array($value)) {
-                $this->_arrayToXml($value, $xml->addChild($key));
+                if ($this->_isAssoc($value)){ //assoc
+                  $this->_arrayToXml($value, $xml->addChild($key));
+                }
+                else{ //indexed
+                  foreach ($value as $sub_value){
+                    $xml->addChild($key, $sub_value);
+                  }
+                }
             } else {
                 $xml->addChild($key, $value);
             }
         }
 
         return $xml;
+    }
+    
+    protected function _isAssoc(array $arr)
+    {
+        if (array() === $arr) return false;
+        return array_keys($arr) !== range(0, count($arr) - 1);
     }
 
     /**


### PR DESCRIPTION
Associative arrays convert directly to XML. However, there's no directly convertable array representation that supports duplicate keys, whereas the Plesk XML API requires it. 
Therefore indexed arrays should create duplicating 'key' XML elements. Example:
`<greeting>
    <hi>hola</hi>
    <hi>hello</hi>
    <hi>bonjour</hi>
</greeting>`

Can be represented in array form as:
`array('greeting' => array('hi' => array('hola', 'hello', 'bonjour')));`

Currently, as far as I can tell, you simply can't pass an array into this library that uses data in this manner, yet `<filter>` requests often require it.