### PR TITLE
Add determining of arrays with duplicate key values

### DIFF
--- a/src/PleskX/Api/Client.php
+++ b/src/PleskX/Api/Client.php
@@ -339,19 +339,30 @@ class Client
      *
      * @param array $array
      * @param SimpleXMLElement $xml
+     * @param string $parentEl
      * @return SimpleXMLElement
      */
-    protected function _arrayToXml(array $array, SimpleXMLElement $xml)
+    protected function _arrayToXml(array $array, SimpleXMLElement $xml, $parentEl = null)
     {
         foreach ($array as $key => $value) {
+            $el = is_int($key) && $parentEl ? $parentEl : $key;
             if (is_array($value)) {
-                $this->_arrayToXml($value, $xml->addChild($key));
+                $this->_arrayToXml($value, $this->_isAssocArray($value) ? $xml->addChild($el) : $xml, $el);
             } else {
-                $xml->addChild($key, $value);
+                $xml->addChild($el, $value);
             }
         }
 
         return $xml;
+    }
+
+    /**
+     * @param array $array
+     * @return bool
+     */
+    protected function _isAssocArray(array $array)
+    {
+        return $array && array_keys($array) !== range(0, count($array) - 1);
     }
 
     /**

--- a/tests/WebspaceTest.php
+++ b/tests/WebspaceTest.php
@@ -61,6 +61,78 @@ class WebspaceTest extends TestCase
         static::$_client->webspace()->delete('id', $webspace->id);
     }
 
+    public function testRequestCreateWebspace()
+    {
+        $webspace = static::$_client->webspace()->request([
+            'add' => [
+                'gen_setup' => [
+                    'name' => 'example-second-test.dom',
+                    'htype' => 'vrt_hst',
+                    'status' => '0',
+                    'ip_address' => [static::_getIpAddress()],
+                ],
+                'hosting' => [
+                    'vrt_hst' => [
+                        'property' => [
+                            [
+                                'name' => 'php_handler_id',
+                                'value' => 'fastcgi',
+                            ],
+                            [
+                                'name' => 'ftp_login',
+                                'value' => 'ftp-login-test-1',
+                            ],
+                            [
+                                'name' => 'ftp_password',
+                                'value' => 'ftp-password-test-1',
+                            ],
+                        ],
+                        'ip_address' => static::_getIpAddress(),
+                    ],
+                ],
+                'limits' => [
+                    'overuse' => 'block',
+                    'limit' => [
+                        [
+                            'name' => 'mbox_quota',
+                            'value' => 100,
+                        ],
+                    ],
+                ],
+                'prefs' => [
+                    'www' => 'false',
+                    'stat_ttl' => 6,
+                ],
+                'performance' => [
+                    'bandwidth' => 120,
+                    'max_connections' => 10000,
+                ],
+                'permissions' => [
+                    'permission' => [
+                        [
+                            'name' => 'manage_sh_access',
+                            'value' => 'true',
+                        ],
+                    ],
+                ],
+                'php-settings' => [
+                    'setting' => [
+                        [
+                            'name' => 'memory_limit',
+                            'value' => '128M',
+                        ],
+                        [
+                            'name' => 'safe_mode',
+                            'value' => 'false',
+                        ],
+                    ],
+                ],
+                'plan-name' => 'Unlimited',
+            ],
+        ]);
+        static::$_client->webspace()->delete('id', $webspace->id);
+    }
+
     public function testDelete()
     {
         $domain = $this->_createDomain();


### PR DESCRIPTION
Now in the API-library there is no possibility to specify an XML-structure, in which there are several elements with the same element names.

For example, there is the following XML query:

```xml
<vrt_hst>
    <property>
        <name>php_handler_id</name>
        <value>fastcgi</value>
    </property>
    <property>
        <name>ftp_login</name>
        <value>ftp-login</value>
    </property>
    <property>
        <name>ftp_password</name>
        <value>ftp-pwd</value>
    </property>
    <ip_address>192.168.0.1</ip_address>
</vrt_hst>
```

Now it can be represented as:

```php
[
    'vrt_hst' => [
        'property' => [
            [
                'name' => 'php_handler_id',
                'value' => 'fastcgi',
            ],
            [
                'name' => 'ftp_login',
                'value' => 'ftp-login',
            ],
            [
                'name' => 'ftp_password',
                'value' => 'ftp-pwd',
            ],
        ],
        'ip_address' => [
            '192.168.0.1',
        ],
    ],
];
```