### PR TITLE
Ensure tests can be passed with the 'Very strong' password policy

### DIFF
--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -2,6 +2,7 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\KeyLimitChecker;
 use PleskXTest\Utility\PasswordProvider;
 
 class CustomerTest extends TestCase
@@ -55,7 +56,7 @@ class CustomerTest extends TestCase
     {
         $keyInfo = static::$_client->server()->getKeyInfo();
 
-        if ((int)$keyInfo['lim_cl'] < 2) {
+        if (!KeyLimitChecker::checkByType($keyInfo, KeyLimitChecker::LIMIT_CLIENTS, 2)) {
             $this->markTestSkipped('License does not allow to create more than 1 customer.');
         }
 

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -2,17 +2,24 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\PasswordProvider;
+
 class CustomerTest extends TestCase
 {
-    private $_customerProperties = [
-        'cname' => 'Plesk',
-        'pname' => 'John Smith',
-        'login' => 'john-unit-test',
-        'passwd' => 'simple-password',
-        'email' => 'john@smith.com',
-        'external-id' => 'link:12345',
-        'description' => 'Good guy',
-    ];
+    private $_customerProperties;
+
+    public function setUp()
+    {
+        $this->_customerProperties = [
+            'cname' => 'Plesk',
+            'pname' => 'John Smith',
+            'login' => 'john-unit-test',
+            'passwd' => PasswordProvider::STRONG_PASSWORD,
+            'email' => 'john@smith.com',
+            'external-id' => 'link:12345',
+            'description' => 'Good guy',
+        ];
+    }
 
     public function testCreate()
     {
@@ -55,12 +62,12 @@ class CustomerTest extends TestCase
         static::$_client->customer()->create([
             'pname' => 'John Smith',
             'login' => 'customer-a',
-            'passwd' => 'simple-password',
+            'passwd' => PasswordProvider::STRONG_PASSWORD,
         ]);
         static::$_client->customer()->create([
             'pname' => 'Mike Black',
             'login' => 'customer-b',
-            'passwd' => 'simple-password',
+            'passwd' => PasswordProvider::STRONG_PASSWORD,
         ]);
 
         $customersInfo = static::$_client->customer()->getAll();

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -2,6 +2,8 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\PasswordProvider;
+
 class DatabaseTest extends TestCase
 {
     /** @var \PleskX\Api\Struct\Webspace\Info */
@@ -35,7 +37,7 @@ class DatabaseTest extends TestCase
         $user = $this->_createUser([
             'db-id' => $database->id,
             'login' => 'test_user1',
-            'password' => 'setup1Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
         static::$_client->database()->deleteUser('id', $user->id);
         static::$_client->database()->delete('id', $database->id);
@@ -52,12 +54,12 @@ class DatabaseTest extends TestCase
         $user = $this->_createUser([
             'db-id' => $database->id,
             'login' => 'test_user1',
-            'password' => 'setup1Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
         $updatedUser = static::$_client->database()->updateUser([
             'id' => $user->id,
             'login' => 'test_user2',
-            'password' => 'setup2Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
         $this->assertEquals(true, $updatedUser);
         static::$_client->database()->deleteUser('id', $user->id);
@@ -118,7 +120,7 @@ class DatabaseTest extends TestCase
         $user = $this->_createUser([
             'db-id' => $database->id,
             'login' => 'test_user1',
-            'password' => 'setup1Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
 
         $dbUser = static::$_client->database()->getUser('id', $user->id);
@@ -146,19 +148,19 @@ class DatabaseTest extends TestCase
         $user1 = $this->_createUser([
             'db-id' => $db1->id,
             'login' => 'test_user1',
-            'password' => 'setup1Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
 
         $user2 = $this->_createUser([
             'db-id' => $db1->id,
             'login' => 'test_user2',
-            'password' => 'setup1Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
 
         $user3 = $this->_createUser([
             'db-id' => $db2->id,
             'login' => 'test_user3',
-            'password' => 'setup1Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
 
         $dbUsers = static::$_client->database()->getAllUsers('db-id', $db1->id);
@@ -196,7 +198,7 @@ class DatabaseTest extends TestCase
         $user = $this->_createUser([
             'db-id' => $database->id,
             'login' => 'test_user1',
-            'password' => 'setup1Q',
+            'password' => PasswordProvider::STRONG_PASSWORD,
         ]);
 
         $result = static::$_client->database()->deleteUser('id', $user->id);

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -2,6 +2,8 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\PasswordProvider;
+
 class MailTest extends TestCase
 {
     /** @var \PleskX\Api\Struct\Webspace\Info */
@@ -35,7 +37,7 @@ class MailTest extends TestCase
 
     public function testCreate()
     {
-        $mailname = static::$_client->mail()->create('test', static::$webspace->id, true, 'secret');
+        $mailname = static::$_client->mail()->create('test', static::$webspace->id, true, PasswordProvider::STRONG_PASSWORD);
 
         $this->assertIsInt($mailname->id);
         $this->assertGreaterThan(0, $mailname->id);

--- a/tests/ProtectedDirectoryTest.php
+++ b/tests/ProtectedDirectoryTest.php
@@ -2,6 +2,8 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\PasswordProvider;
+
 class ProtectedDirectoryTest extends TestCase
 {
     /** @var \PleskX\Api\Struct\Webspace\Info */
@@ -64,7 +66,7 @@ class ProtectedDirectoryTest extends TestCase
     {
         $protectedDirectory = static::$_client->protectedDirectory()->add('/', static::$webspace->id);
 
-        $user = static::$_client->protectedDirectory()->addUser($protectedDirectory, 'john', 'secret');
+        $user = static::$_client->protectedDirectory()->addUser($protectedDirectory, 'john', PasswordProvider::STRONG_PASSWORD);
         $this->assertGreaterThan(0, $user->id);
 
         static::$_client->protectedDirectory()->delete('id', $protectedDirectory->id);
@@ -74,7 +76,7 @@ class ProtectedDirectoryTest extends TestCase
     {
         $protectedDirectory = static::$_client->protectedDirectory()->add('/', static::$webspace->id);
 
-        $user = static::$_client->protectedDirectory()->addUser($protectedDirectory, 'john', 'secret');
+        $user = static::$_client->protectedDirectory()->addUser($protectedDirectory, 'john', PasswordProvider::STRONG_PASSWORD);
         $result = static::$_client->protectedDirectory()->deleteUser('id', $user->id);
         $this->assertTrue($result);
 

--- a/tests/ResellerTest.php
+++ b/tests/ResellerTest.php
@@ -2,6 +2,7 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\KeyLimitChecker;
 use PleskXTest\Utility\PasswordProvider;
 
 class ResellerTest extends TestCase
@@ -48,7 +49,7 @@ class ResellerTest extends TestCase
     {
         $keyInfo = static::$_client->server()->getKeyInfo();
 
-        if ((int)$keyInfo['lim_cl'] < 2) {
+        if (!KeyLimitChecker::checkByType($keyInfo, KeyLimitChecker::LIMIT_RESELLERS, 2)) {
             $this->markTestSkipped('License does not allow to create more than 1 reseller.');
         }
 

--- a/tests/ResellerTest.php
+++ b/tests/ResellerTest.php
@@ -2,13 +2,20 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\PasswordProvider;
+
 class ResellerTest extends TestCase
 {
-    private $_resellerProperties = [
-        'pname' => 'John Reseller',
-        'login' => 'reseller-unit-test',
-        'passwd' => 'simple-password',
-    ];
+    private $_resellerProperties;
+
+    public function setUp()
+    {
+        $this->_resellerProperties = [
+            'pname' => 'John Reseller',
+            'login' => 'reseller-unit-test',
+            'passwd' => PasswordProvider::STRONG_PASSWORD,
+        ];
+    }
 
     public function testCreate()
     {
@@ -48,12 +55,12 @@ class ResellerTest extends TestCase
         static::$_client->reseller()->create([
             'pname' => 'John Reseller',
             'login' => 'reseller-a',
-            'passwd' => 'simple-password',
+            'passwd' => PasswordProvider::STRONG_PASSWORD,
         ]);
         static::$_client->reseller()->create([
             'pname' => 'Mike Reseller',
             'login' => 'reseller-b',
-            'passwd' => 'simple-password',
+            'passwd' => PasswordProvider::STRONG_PASSWORD,
         ]);
 
         $resellersInfo = static::$_client->reseller()->getAll();

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -2,6 +2,8 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\KeyLimitChecker;
+
 class SiteTest extends TestCase
 {
     /** @var \PleskX\Api\Struct\Webspace\Info */
@@ -19,7 +21,7 @@ class SiteTest extends TestCase
 
         $keyInfo = static::$_client->server()->getKeyInfo();
 
-        if ((int)$keyInfo['lim_dom'] < 2) {
+        if (!KeyLimitChecker::checkByType($keyInfo, KeyLimitChecker::LIMIT_DOMAINS, 2)) {
             $this->markTestSkipped('License does not allow to create more than 1 domain.');
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,8 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\PasswordProvider;
+
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /** @var \PleskX\Api\Client */
@@ -52,15 +54,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected static function _createWebspace()
     {
         $id = uniqid();
-        $password = base64_encode(time());
-
         $webspace = static::$_client->webspace()->create(
             [
                 'name' => "test{$id}.test",
                 'ip_address' => static::_getIpAddress(),
             ], [
                 'ftp_login' => "u{$id}",
-                'ftp_password' => $password,
+                'ftp_password' => PasswordProvider::STRONG_PASSWORD,
             ]
         );
         self::$webspaces[] = $webspace;

--- a/tests/Utility/KeyLimitChecker.php
+++ b/tests/Utility/KeyLimitChecker.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PleskXTest\Utility;
+
+class KeyLimitChecker
+{
+    const LIMIT_CLIENTS = 'limit_clients';
+    const LIMIT_RESELLERS = 'limit_resellers';
+    const LIMIT_DOMAINS = 'limit_domains';
+
+    /**
+     * Checks whether limit is within the required constraint
+     *
+     * @param (string|int)[] $keyInfo  Structure returned by the getKeyInfo call
+     * @param string $type             Type of the object that should be checked
+     * @param int $minimalRequirement  Minimal value that should satisfy the limit
+     * @return bool  if license satisfies set limits
+     */
+    public static function checkByType(array $keyInfo, $type, $minimalRequirement)
+    {
+        $field = null;
+        switch ($type) {
+            case self::LIMIT_CLIENTS:
+                if (intval($keyInfo['can-manage-customers']) === 0) {
+                    return false;
+                }
+                $field = 'lim_cl';
+                break;
+            case self::LIMIT_RESELLERS:
+                if (intval($keyInfo['can-manage-resellers']) === 0) {
+                    return false;
+                }
+                $field = 'lim_cl';
+                break;
+            case self::LIMIT_DOMAINS:
+                $field = 'lim_dom';
+                break;
+            default:
+                return false;
+        }
+        return intval($keyInfo[$field]) === -1 || intval($keyInfo[$field]) > $minimalRequirement;
+    }
+}

--- a/tests/Utility/PasswordProvider.php
+++ b/tests/Utility/PasswordProvider.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PleskXTest\Utility;
+
+class PasswordProvider
+{
+    const STRONG_PASSWORD = 'test-PWD*1@42!13#';
+}

--- a/tests/WebspaceTest.php
+++ b/tests/WebspaceTest.php
@@ -2,6 +2,8 @@
 // Copyright 1999-2019. Plesk International GmbH.
 namespace PleskXTest;
 
+use PleskXTest\Utility\PasswordProvider;
+
 class WebspaceTest extends TestCase
 {
     public function testGetPermissionDescriptor()
@@ -96,7 +98,7 @@ class WebspaceTest extends TestCase
                             ],
                             [
                                 'name' => 'ftp_password',
-                                'value' => 'test-PWD*1',
+                                'value' => PasswordProvider::STRONG_PASSWORD,
                             ],
                         ],
                         'ip_address' => static::_getIpAddress(),


### PR DESCRIPTION
Currently, tests only pass with weaker policies.

Additional changes in this PR are to allow passing '&' symbol in the password entity and to enable tests on licenses with unlimited customers/domains/resellers.