### PR TITLE
Adding get() and getAll() to SiteAlias

### DIFF
--- a/src/Api/Operator/SiteAlias.php
+++ b/src/Api/Operator/SiteAlias.php
@@ -32,4 +32,38 @@ class SiteAlias extends \PleskX\Api\Operator
         return new Struct\Info($response);
     }
 
+    /**
+     * @param string $field
+     * @param integer|string $value
+     * @return Struct\Info
+     */
+    public function get($field, $value)
+    {
+        $items = $this->getAll($field, $value);
+        return reset($items);
+    }
+
+    /**
+     * @param string $field
+     * @param integer|string $value
+     * @return Struct\Info[]
+     */
+    public function getAll($field = null, $value = null)
+    {
+        $packet = $this->_client->getPacket();
+        $getTag = $packet->addChild($this->_wrapperTag)->addChild('get');
+
+        $filterTag = $getTag->addChild('filter');
+        if (!is_null($field)) {
+            $filterTag->addChild($field, $value);
+        }
+
+        $response = $this->_client->request($packet, \PleskX\Api\Client::RESPONSE_FULL);
+        $items = [];
+        foreach ($response->xpath('//result') as $xmlResult) {
+            $item = new Struct\GeneralInfo($xmlResult->info);
+            $items[] = $item;
+        }
+        return $items;
+    }
 }

--- a/src/Api/Struct/SiteAlias/GeneralInfo.php
+++ b/src/Api/Struct/SiteAlias/GeneralInfo.php
@@ -1,0 +1,25 @@
+<?php
+// Copyright 1999-2019. Plesk International GmbH.
+
+namespace PleskX\Api\Struct\SiteAlias;
+
+class GeneralInfo extends \PleskX\Api\Struct
+{
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $asciiName;
+
+    /** @var string */
+    public $status;
+
+    public function __construct($apiResponse)
+    {
+        $this->_initScalarProperties($apiResponse, [
+            'name',
+            'ascii-name',
+            'status',
+        ]);
+    }
+}


### PR DESCRIPTION
This adds the get() and getAll() functions for Site Aliases like its already possible for Sites and for Webspaces.