### PR TITLE
avoiding usage of _expandRequestShortSyntax

### DIFF
--- a/src/Api/Operator.php
+++ b/src/Api/Operator.php
@@ -54,9 +54,14 @@ class Operator
      */
     protected function _delete($field, $value, $deleteMethodName = 'del')
     {
-        $response = $this->request("$deleteMethodName.filter.$field=$value");
-
-        return 'ok' === (string) $response->status;
+        $response = $this->request([
+            $deleteMethodName=>[
+                'filter'=>[
+                    $field=>$value
+                ]
+            ]
+        ]);
+        return 'ok' === (string)$response->status;
     }
 
     /**


### PR DESCRIPTION
This PR passes an array in purpose to avoid _expandRequestShortSyntax, as result the program will hit [here](https://github.com/plesk/api-php-lib/blob/master/src/Api/Client.php#L148) instead of "_expandRequestShortSyntax". The main problem is that function can't parse a string like `database.del-db.filter.webspace-name=testdomain.com` because it uses '.' as parameter and as result all we got is;

```
array:5 [
  0 => "database"
  1 => "del-db"
  2 => "filter"
  3 => "webspace-name=testdomain"
  4 => "com"
]
```

```
<?xml version="1.0" encoding="UTF-8"?>\n

<packet>
	<database>
		<del-db>
			<filter>
				<webspace-name>testdomain
					<com/>
				</webspace-name>
			</filter>
		</del-db>
	</database>
</packet>
```

and this causes to broken xml output which can't processed by plesk.