### PR TITLE
Update SecretKey.php

### DIFF
--- a/src/Api/Operator/SecretKey.php
+++ b/src/Api/Operator/SecretKey.php
@@ -11,13 +11,20 @@ class SecretKey extends \PleskX\Api\Operator
 
     /**
      * @param string $ipAddress
+     * @param string $keyDescription
      *
      * @return string
      */
-    public function create($ipAddress)
+    public function create($ipAddress = '', $keyDescription = '')
     {
         $packet = $this->_client->getPacket();
-        $packet->addChild($this->_wrapperTag)->addChild('create')->addChild('ip_address', $ipAddress);
+        $creator = $packet->addChild($this->_wrapperTag)->addChild('create');
+
+        if ($ipAddress != '') {
+            $creator->addChild('ip_address', $ipAddress);
+        }
+        $creator->addChild('description', $keyDescription);
+
         $response = $this->_client->request($packet);
 
         return (string) $response->key;


### PR DESCRIPTION
Make IP address optional. If not provided don't add the ip_address child to the request. This will make Plesk take the IP of the sender. ("If this node is not specified, the IP address of the request sender will be used.")