### PR TITLE
Add additional fields to Struct Webspace\GeneralInfo

### DIFF
--- a/src/Api/Struct/Webspace/GeneralInfo.php
+++ b/src/Api/Struct/Webspace/GeneralInfo.php
@@ -6,20 +6,56 @@ namespace PleskX\Api\Struct\Webspace;
 class GeneralInfo extends \PleskX\Api\Struct
 {
     /** @var string */
+    public $crDate;
+
+    /** @var string */
     public $name;
 
     /** @var string */
-    public $guid;
+    public $asciiName;
+
+    /** @var string */
+    public $status;
 
     /** @var int */
     public $realSize;
 
+    /** @var int */
+    public $ownerId;
+
+    /** @var array */
+    public $ipAddresses = [];
+
+    /** @var string */
+    public $guid;
+
+    /** @var string */
+    public $vendorGuid;
+
+    /** @var string */
+    public $description;
+
+    /** @var string */
+    public $adminDescription;
+
     public function __construct($apiResponse)
     {
         $this->_initScalarProperties($apiResponse, [
+            'cr_date',
             'name',
-            'guid',
+            'ascii-name',
+            'status',
             'real_size',
+            'owner-id',
+            'guid',
+            'vendor-guid',
+            'description',
+            'admin-description'
         ]);
+
+        foreach($apiResponse->dns_ip_address as $ip)
+        {
+            $this->ipAddresses[] = (string)$ip;
+        }
     }
 }

--- a/src/Api/Struct/Webspace/GeneralInfo.php
+++ b/src/Api/Struct/Webspace/GeneralInfo.php
@@ -53,7 +53,7 @@ class GeneralInfo extends \PleskX\Api\Struct
             'admin-description',
         ]);
 
-        foreach($apiResponse->dns_ip_address as $ip) {
+        foreach ($apiResponse->dns_ip_address as $ip) {
             $this->ipAddresses[] = (string) $ip;
         }
     }

--- a/src/Api/Struct/Webspace/GeneralInfo.php
+++ b/src/Api/Struct/Webspace/GeneralInfo.php
@@ -50,12 +50,11 @@ class GeneralInfo extends \PleskX\Api\Struct
             'guid',
             'vendor-guid',
             'description',
-            'admin-description'
+            'admin-description',
         ]);
 
-        foreach($apiResponse->dns_ip_address as $ip)
-        {
-            $this->ipAddresses[] = (string)$ip;
+        foreach($apiResponse->dns_ip_address as $ip) {
+            $this->ipAddresses[] = (string) $ip;
         }
     }
 }


### PR DESCRIPTION
I've noticed that the struct is missing some fields which are present in the API Response.