### PR TITLE
Switch to new Plesk image for tests in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,17 @@
 version: '2'
 services:
   plesk:
-    image: plesk/plesk:tests
+    image: plesk/plesk:latest
     logging:
       driver: none
     ports:
       ["8443:8443"]
+    tmpfs:
+      - /tmp
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   tests:
     build: .
     environment:
@@ -18,4 +24,3 @@ services:
       - plesk
     volumes:
       - .:/opt/api-php-lib
-


### PR DESCRIPTION
The new image contains real systemd and is required for Plesk >= 18.0.36.
It already contains all components required by tests.

Best to merge this after the [respective PR](https://github.com/plesk/docker/pull/39) is merged and Plesk 18.0.36 is released.