### PR TITLE
Get IDs as array index for item lists

### DIFF
--- a/src/Api/Operator.php
+++ b/src/Api/Operator.php
@@ -96,7 +96,11 @@ class Operator
             if (!isset($xmlResult->data) || !isset($xmlResult->data->$infoTag)) {
                 continue;
             }
-            $items[] = new $structClass($xmlResult->data->$infoTag);
+            if (isset($xmlResult->id)) {
+                $items[(integer) $xmlResult->id] = new $structClass($xmlResult->data->$infoTag);
+            } else {
+                $items[] = new $structClass($xmlResult->data->$infoTag);
+            }
         }
 
         return $items;

--- a/src/Api/Operator.php
+++ b/src/Api/Operator.php
@@ -97,7 +97,7 @@ class Operator
                 continue;
             }
             if (isset($xmlResult->id)) {
-                $items[(integer) $xmlResult->id] = new $structClass($xmlResult->data->$infoTag);
+                $items[(int) $xmlResult->id] = new $structClass($xmlResult->data->$infoTag);
             } else {
                 $items[] = new $structClass($xmlResult->data->$infoTag);
             }


### PR DESCRIPTION
Get the Plesk item ID as array index in Plesk item lists (e.g. sites). If no id is provided in the result there is no index used from Plesk response.
Useful for issue #88 