### PR TITLE
[Webspace] Allow multiple IP addresses to be passed as an array

### DIFF
--- a/src/Api/Operator/Webspace.php
+++ b/src/Api/Operator/Webspace.php
@@ -75,6 +75,10 @@ class Webspace extends Operator
 
         $infoGeneral = $info->addChild('gen_setup');
         foreach ($properties as $name => $value) {
+            if ('ip_address' === $name) {
+                continue;
+            }
+
             $infoGeneral->addChild($name, $value);
         }
 


### PR DESCRIPTION
As described in https://github.com/plesk/api-php-lib/issues/110 right now we run into an error when trying to add multiple IP addresses as array.

This PR ignores the `ip_address` property and therefore does no longer try to add it to the general info as XML child node.

Resolves https://github.com/plesk/api-php-lib/issues/110