### PR TITLE
BUGFIX EXTREST-143 Extend already set properties instead of overwriting them

### DIFF
--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -361,8 +361,10 @@ class Client
             $el = is_int($key) && $parentEl ? $parentEl : $key;
             if (is_array($value)) {
                 $this->arrayToXml($value, $this->isAssocArray($value) ? $xml->addChild($el) : $xml, $el);
-            } else {
+            } elseif(!isset($xml->{$el})) {
                 $xml->{$el} = (string) $value;
+            } else {
+                $xml->{$el}[] = (string) $value;
             }
         }
 


### PR DESCRIPTION
Fixes overwriting ip_address node value with the last one in array for EXTREST-143 (and, likely, all cases when array is supplied instead of the XML packet to the \PleskX\Api\Client::request)