### PR TITLE
hotfix@customers/webspaces[statuses]

### DIFF
--- a/src/Api/Operator/Customer.php
+++ b/src/Api/Operator/Customer.php
@@ -72,7 +72,7 @@ class Customer extends \PleskX\Api\Operator
      */
     public function disable(string $field, $value): bool
     {
-        return $this->setProperties($field, $value, ['status' => 1]);
+        return $this->setProperties($field, $value, ['status' => 16]);
     }
 
     /**

--- a/src/Api/Operator/Webspace.php
+++ b/src/Api/Operator/Webspace.php
@@ -172,7 +172,7 @@ class Webspace extends Operator
      */
     public function disable(string $field, $value): bool
     {
-        return $this->setProperties($field, $value, ['status' => 1]);
+        return $this->setProperties($field, $value, ['status' => 16]);
     }
 
     /**


### PR DESCRIPTION
For customers allowed status can be only 0 or 16. Also webspaces(subscribtions) allowed values: 0 (active) | 16 (disabled_by admin)  (there is no status "1")-- when status 1 is provided on customer plesk db is crashing somehow and customer stacked in disabled mode.

---------
https://docs.plesk.com/en-US/obsidian/api-rpc/about-xml-api/reference/managing-customer-accounts/customer-settings/general-customer-account-settings/type-clientsetgeninfo.34625/
---------
https://docs.plesk.com/en-US/obsidian/api-rpc/about-xml-api/reference/managing-subscriptions/subscription-settings/general-subscription-information/node-gen_setup-type-setgensetuptype.33860