### PR TITLE
BUGFIX EXTPLESK-8950 Fix case when getAll returns 1 database instead of 0

### DIFF
--- a/src/Api/Operator/Database.php
+++ b/src/Api/Operator/Database.php
@@ -78,7 +78,7 @@ class Database extends \PleskX\Api\Operator
         $response = $this->getBy('get-db', $field, $value);
         $items = [];
         foreach ((array) $response->xpath('//result') as $xmlResult) {
-            if ($xmlResult) {
+            if ($xmlResult && isset($xmlResult->id) && (int) $xmlResult->id > 0) {
                 $items[] = new Struct\Info($xmlResult);
             }
         }

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -225,4 +225,12 @@ class DatabaseTest extends AbstractTestCase
 
         return $user;
     }
+
+    public function testGetAllForWebspaceWithNoDatabases()
+    {
+        $databases = static::$client->database()->getAll('webspace-id', static::$webspace->id);
+
+        $this->assertIsArray($databases);
+        $this->assertEmpty($databases);
+    }
 }


### PR DESCRIPTION
When there are no databases on a domain, the API returns:
```
<?xml version="1.0" encoding="UTF-8"?>
<packet version="1.6.9.1">
    <database>
        <get-db>
            <result>
                <status>ok</status>
                <filter-id>nodatabase.com</filter-id>
            </result>
        </get-db>
    </database>
</packet>

```
However, the getAll method returns one object with empty values (because if ($xmlResult) is always true, even when there are no DBs).